### PR TITLE
Integrate P2P network with mining loop

### DIFF
--- a/docs/TODO-blockchain.md
+++ b/docs/TODO-blockchain.md
@@ -1,0 +1,19 @@
+# Luracoin - Roadmap to Complete Blockchain
+
+## Esencial
+
+- [ ] **1. Integrar P2P con el miner** -- Al minar, broadcast a peers. Al recibir bloque, parar mining y empezar siguiente. Recibir TXs de peers al mempool.
+- [ ] **2. Ajuste de dificultad integrado** -- Llamar a `calculate_new_bits()` cada `DIFFICULTY_ADJUSTMENT_INTERVAL` bloques en vez de usar siempre `STARTING_DIFFICULTY`.
+- [ ] **3. Validar prev_block_hash** -- `Block.validate()` debe comprobar que `prev_block_hash` sea el hash real del bloque anterior.
+- [ ] **4. Longest chain rule** -- Seleccionar la cadena más larga cuando hay forks. Dos miners con bloque simultáneo → elegir la cadena con más trabajo acumulado.
+
+## Importante
+
+- [ ] **5. Merkle tree** -- Merkle root en el header del bloque para verificación eficiente de transacciones.
+- [ ] **6. HTTP API / RPC** -- API JSON-RPC para que wallets y apps interactúen con el nodo.
+- [ ] **7. Chain reorganization** -- Rollback de transacciones y re-aplicar cuando llega una cadena más larga.
+
+## Cosmético
+
+- [ ] **8. Persistir peers en disco** -- Guardar peers conocidos para no depender solo de seed nodes al reiniciar.
+- [ ] **9. Compact block propagation** -- Enviar solo headers + short tx IDs en vez de bloques completos.

--- a/luracoin/client.py
+++ b/luracoin/client.py
@@ -3,14 +3,16 @@ Luracoin client
 
 Usage:
   client.py generateWallet
-  client.py mine --address=<address>
+  client.py mine --address=<address> [--port=<port>]
   client.py getBalance <address>
   client.py getBlock <height>
   client.py getInfo
 
 Options:
   -h --help            Show help
+  --port=<port>        P2P listening port [default: 9999]
 """
+import asyncio
 import json
 
 from docopt import docopt
@@ -23,7 +25,8 @@ def main(args):
     if args["generateWallet"]:
         generateWallet()
     elif args["mine"]:
-        mine(args["--address"])
+        port = int(args["--port"] or 9999)
+        mine(args["--address"], port)
     elif args["getBalance"]:
         get_balance(args["<address>"])
     elif args["getBlock"]:
@@ -32,16 +35,12 @@ def main(args):
         get_info()
 
 
-def mine(address):
-    from luracoin.genesis import initialize_chain
-    from luracoin.blocks import Block
+def mine(address, port=9999):
+    from luracoin.network.miner import MiningNode
 
-    initialize_chain()
-
-    while True:
-        block = Block(miner=address)
-        block.create()
-        print(f"Mined block {block.height} | nonce: {block.nonce}")
+    node = MiningNode(address=address, port=port)
+    print(f"Starting mining node on port {port} with address {address}")
+    asyncio.run(node.start())
 
 
 def generateWallet():

--- a/luracoin/network/miner.py
+++ b/luracoin/network/miner.py
@@ -1,0 +1,148 @@
+"""
+Mining node: integrates P2P networking with block mining.
+
+Runs PoW in a thread pool so it doesn't block the asyncio event loop.
+When a new block arrives from a peer, mining is interrupted and restarted.
+"""
+
+import asyncio
+import logging
+import threading
+import time
+
+from luracoin.blocks import Block
+from luracoin.config import Config
+from luracoin.genesis import initialize_chain
+from luracoin.helpers import mining_reward
+from luracoin.pow import proof_of_work
+from luracoin.transactions import Transaction
+from luracoin.network.node import Node
+
+log = logging.getLogger(__name__)
+
+
+class MiningNode:
+    """
+    Full node that mines blocks and participates in the P2P network.
+
+    - Starts P2P server and connects to seeds
+    - Mines blocks in a background thread (interruptible PoW)
+    - Broadcasts mined blocks to peers
+    - Stops mining when a peer's block arrives at our expected height
+    - Listens to peers for blocks/transactions continuously
+    """
+
+    def __init__(self, address: str, port: int = None, seed_nodes: list = None):
+        self.address = address
+        self.node = Node(
+            port=port or Config.PORT,
+            seed_nodes=seed_nodes,
+        )
+        self._stop_mining_event = threading.Event()
+        self._running = False
+
+    async def start(self) -> None:
+        """Initialize chain, start P2P, and begin mining."""
+        initialize_chain()
+
+        # Set callback so node notifies us when a peer's block arrives
+        self.node.on_new_block = self._on_peer_block
+
+        await self.node.start()
+        self._running = True
+
+        # Connect to seeds in background
+        asyncio.create_task(self._connect_and_discover())
+
+        # Start mining loop
+        await self._mining_loop()
+
+    async def stop(self) -> None:
+        self._running = False
+        self._stop_mining_event.set()
+        await self.node.stop()
+
+    def _on_peer_block(self) -> None:
+        """Called by Node when a valid block is received from a peer."""
+        log.info("New block from peer, interrupting mining")
+        self._stop_mining_event.set()
+
+    async def _connect_and_discover(self) -> None:
+        """Connect to seed nodes and periodically discover new peers."""
+        await self.node.connect_to_seeds()
+
+        while self._running:
+            await asyncio.sleep(30)
+            if self._running:
+                await self.node.connect_to_seeds()
+
+    async def _mining_loop(self) -> None:
+        """Main mining loop: build block, run PoW, broadcast, repeat."""
+        loop = asyncio.get_event_loop()
+
+        while self._running:
+            self._stop_mining_event.clear()
+
+            # Build the block template
+            block = self._build_block_template()
+            if block is None:
+                await asyncio.sleep(1)
+                continue
+
+            # Run PoW in thread pool (non-blocking)
+            nonce = await loop.run_in_executor(
+                None, self._mine_block, block
+            )
+
+            if nonce == -1:
+                # Mining was interrupted by a peer's block
+                log.info("Mining interrupted, restarting with new tip")
+                continue
+
+            # Block mined successfully
+            block.save()
+            log.info(f"Mined block {block.height} | nonce: {block.nonce}")
+            print(f"Mined block {block.height} | nonce: {block.nonce}")
+
+            # Broadcast to peers
+            await self.node.broadcast_block(block)
+
+    def _build_block_template(self) -> Block:
+        """Create a block template ready for PoW."""
+        chain = self.node.chain
+
+        prev_block = Block.get(chain.tip)
+        height = chain.tip + 1 if prev_block else 0
+        prev_hash = prev_block.id if prev_block else "0" * 64
+
+        # Select transactions from mempool
+        block = Block(miner=self.address, height=height)
+        try:
+            block.select_transactions()
+        except Exception:
+            block.txns = []
+
+        # Add coinbase
+        total_fees = sum(txn.fee for txn in block.txns)
+        coinbase = Transaction(
+            chain=0,
+            nonce=0,
+            fee=0,
+            value=mining_reward(height) + total_fees,
+            from_address="0" * 34,
+            to_address=self.address,
+            unlock_sig=Config.COINBASE_UNLOCK_SIGNATURE,
+        )
+        block.txns.insert(0, coinbase)
+
+        block.version = 1
+        block.prev_block_hash = prev_hash
+        block.timestamp = int(time.time())
+        block.bits = Config.STARTING_DIFFICULTY
+        block.nonce = 0
+
+        return block
+
+    def _mine_block(self, block: Block) -> int:
+        """Run PoW (called in thread pool). Returns nonce or -1 if interrupted."""
+        return proof_of_work(block, stop_event=self._stop_mining_event)

--- a/luracoin/network/node.py
+++ b/luracoin/network/node.py
@@ -58,6 +58,7 @@ class Node:
         self.running = False
         self._server = None
         self.known_invs: set = set()  # Set of seen inv hashes to avoid re-broadcast
+        self.on_new_block = None  # Callback: called when a valid block is received from a peer
 
     @property
     def connected_addresses(self) -> set:
@@ -216,7 +217,10 @@ class Node:
 
     def _handle_block(self, payload: bytes) -> bool:
         """Process a received block."""
-        return self.block_sync.handle_block(payload)
+        accepted = self.block_sync.handle_block(payload)
+        if accepted and self.on_new_block:
+            self.on_new_block()
+        return accepted
 
     def _handle_tx(self, payload: bytes) -> bool:
         """Process a received transaction."""

--- a/luracoin/pow.py
+++ b/luracoin/pow.py
@@ -1,12 +1,16 @@
-def proof_of_work(block: "Block", starting_at=0) -> int:  # type: ignore
+def proof_of_work(block: "Block", starting_at=0, stop_event=None) -> int:  # type: ignore
     """
-    Simple Proof of Work Algorithm
+    Simple Proof of Work Algorithm.
+
+    If stop_event (threading.Event) is provided, checks it every 1000
+    iterations so mining can be interrupted when a new block arrives
+    from a peer. Returns -1 if interrupted.
     """
     block.nonce = starting_at
-    stop_loop = block.is_valid_proof()
 
-    while not stop_loop:
-        block.nonce = block.nonce + 1
-        stop_loop = block.is_valid_proof()
+    while not block.is_valid_proof():
+        if stop_event and block.nonce % 1000 == 0 and stop_event.is_set():
+            return -1
+        block.nonce += 1
 
     return block.nonce

--- a/tests/network/test_miner.py
+++ b/tests/network/test_miner.py
@@ -1,0 +1,193 @@
+import asyncio
+import threading
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from luracoin.network.miner import MiningNode
+from luracoin.blocks import Block
+from luracoin.transactions import Transaction
+from luracoin.config import Config
+from luracoin.chain import Chain
+from luracoin.helpers import mining_reward
+from tests.constants import WALLET_1
+
+
+# ---------------------------------------------------------------------------
+# MiningNode construction
+# ---------------------------------------------------------------------------
+
+def test_mining_node_creation():
+    node = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    assert node.address == WALLET_1["address"]
+    assert node.node.port == 19999
+    assert node._running is False
+
+
+# ---------------------------------------------------------------------------
+# _build_block_template
+# ---------------------------------------------------------------------------
+
+def test_build_block_template_first_block():
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    block = miner._build_block_template()
+
+    assert block is not None
+    assert block.height == 0
+    assert block.prev_block_hash == "0" * 64
+    assert block.version == 1
+    assert block.miner == WALLET_1["address"]
+    assert len(block.txns) >= 1
+    assert block.txns[0].is_coinbase is True
+    assert block.txns[0].value == mining_reward(0)
+    assert block.txns[0].to_address == WALLET_1["address"]
+
+
+def test_build_block_template_after_genesis():
+    chain = Chain()
+
+    # Save a genesis block
+    coinbase = Transaction(
+        chain=1, nonce=0, fee=0, value=mining_reward(0),
+        from_address="0" * 34, to_address=WALLET_1["address"],
+        unlock_sig=Config.COINBASE_UNLOCK_SIGNATURE,
+    )
+    genesis = Block(
+        version=1, height=0, miner=WALLET_1["address"],
+        prev_block_hash="0" * 64, timestamp=1_623_168_442,
+        bits=b"\x1f\x00\xff\xff", nonce=0, txns=[coinbase],
+    )
+    genesis.save()
+
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    block = miner._build_block_template()
+
+    assert block.height == 1
+    assert block.prev_block_hash == genesis.id
+
+
+# ---------------------------------------------------------------------------
+# _mine_block (interruptible PoW)
+# ---------------------------------------------------------------------------
+
+def test_mine_block_succeeds():
+    """PoW with easy difficulty should succeed."""
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    block = miner._build_block_template()
+    block.bits = b"\x1f\x00\xff\xff"  # easy
+
+    nonce = miner._mine_block(block)
+    assert nonce >= 0
+    assert block.is_valid_proof()
+
+
+def test_mine_block_interrupted():
+    """Setting stop event should interrupt mining."""
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    block = miner._build_block_template()
+    block.bits = b"\x14\x00\xff\xff"  # hard difficulty
+
+    miner._stop_mining_event.set()
+    nonce = miner._mine_block(block)
+    assert nonce == -1
+
+
+# ---------------------------------------------------------------------------
+# _on_peer_block callback
+# ---------------------------------------------------------------------------
+
+def test_on_peer_block_sets_stop_event():
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    assert not miner._stop_mining_event.is_set()
+
+    miner._on_peer_block()
+    assert miner._stop_mining_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# stop()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stop_sets_running_false():
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    miner._running = True
+    miner.node.stop = AsyncMock()
+
+    await miner.stop()
+
+    assert miner._running is False
+    assert miner._stop_mining_event.is_set()
+    miner.node.stop.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Node callback integration
+# ---------------------------------------------------------------------------
+
+def test_node_on_new_block_callback_is_set_on_start():
+    """After constructing MiningNode, on_new_block should be None.
+    It gets set during start(), but we can test the wiring manually."""
+    miner = MiningNode(address=WALLET_1["address"], port=19999, seed_nodes=[])
+    # Simulate what start() does
+    miner.node.on_new_block = miner._on_peer_block
+
+    assert miner.node.on_new_block is not None
+    miner.node.on_new_block()
+    assert miner._stop_mining_event.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Node._handle_block calls on_new_block
+# ---------------------------------------------------------------------------
+
+def test_node_handle_block_triggers_callback():
+    """When node receives a valid block, on_new_block callback fires."""
+    from luracoin.network.node import Node
+    from luracoin.pow import proof_of_work
+
+    node = Node(port=19999, seed_nodes=[])
+    callback_called = []
+    node.on_new_block = lambda: callback_called.append(True)
+
+    # Save genesis so handle_block expects height=1
+    coinbase = Transaction(
+        chain=1, nonce=0, fee=0, value=mining_reward(0),
+        from_address="0" * 34, to_address=WALLET_1["address"],
+        unlock_sig=Config.COINBASE_UNLOCK_SIGNATURE,
+    )
+    genesis = Block(
+        version=1, height=0, miner=WALLET_1["address"],
+        prev_block_hash="0" * 64, timestamp=1_623_168_442,
+        bits=b"\x1f\x00\xff\xff", nonce=0, txns=[coinbase],
+    )
+    genesis.save()
+
+    # Create valid block at height 1
+    coinbase1 = Transaction(
+        chain=1, nonce=0, fee=0, value=mining_reward(1),
+        from_address="0" * 34, to_address=WALLET_1["address"],
+        unlock_sig=Config.COINBASE_UNLOCK_SIGNATURE,
+    )
+    block1 = Block(
+        version=1, height=1, miner=WALLET_1["address"],
+        prev_block_hash=genesis.id, timestamp=1_623_168_500,
+        bits=b"\x1f\x00\xff\xff", nonce=0, txns=[coinbase1],
+    )
+    proof_of_work(block1)
+
+    accepted = node._handle_block(block1.serialize())
+    assert accepted is True
+    assert len(callback_called) == 1
+
+
+def test_node_handle_block_no_callback_on_reject():
+    """Callback should NOT fire when block is rejected."""
+    from luracoin.network.node import Node
+
+    node = Node(port=19999, seed_nodes=[])
+    callback_called = []
+    node.on_new_block = lambda: callback_called.append(True)
+
+    # Invalid block data
+    accepted = node._handle_block(b"garbage")
+    assert accepted is False
+    assert len(callback_called) == 0

--- a/tests/test_pow_interruptible.py
+++ b/tests/test_pow_interruptible.py
@@ -1,0 +1,64 @@
+import threading
+from luracoin.blocks import Block
+from luracoin.transactions import Transaction
+from luracoin.config import Config
+from luracoin.pow import proof_of_work
+from tests.constants import WALLET_1
+
+
+def _make_block(bits=b"\x1f\x00\xff\xff"):
+    coinbase = Transaction(
+        chain=1, nonce=0, fee=0, value=50000,
+        from_address="0" * 34, to_address=WALLET_1["address"],
+        unlock_sig=Config.COINBASE_UNLOCK_SIGNATURE,
+    )
+    return Block(
+        version=1, height=0, miner=WALLET_1["address"],
+        prev_block_hash="0" * 64, timestamp=1_623_168_442,
+        bits=bits, nonce=0, txns=[coinbase],
+    )
+
+
+def test_pow_without_stop_event_works():
+    block = _make_block()
+    nonce = proof_of_work(block)
+    assert nonce >= 0
+    assert block.is_valid_proof()
+
+
+def test_pow_with_stop_event_not_set_works():
+    block = _make_block()
+    event = threading.Event()
+    nonce = proof_of_work(block, stop_event=event)
+    assert nonce >= 0
+    assert block.is_valid_proof()
+
+
+def test_pow_interrupted_returns_minus_one():
+    # Use hard difficulty so it takes many iterations
+    block = _make_block(bits=b"\x1d\x00\xff\xff")
+    event = threading.Event()
+    event.set()  # Set immediately so it stops at first check
+
+    nonce = proof_of_work(block, stop_event=event)
+    assert nonce == -1
+
+
+def test_pow_stop_event_set_during_mining():
+    """Start mining, set stop after a short delay, verify interruption."""
+    block = _make_block(bits=b"\x14\x00\xff\xff")  # Hard difficulty
+    event = threading.Event()
+
+    def set_after_delay():
+        # Set event after a tiny delay
+        import time
+        time.sleep(0.01)
+        event.set()
+
+    timer = threading.Thread(target=set_after_delay)
+    timer.start()
+
+    nonce = proof_of_work(block, stop_event=event)
+    timer.join()
+
+    assert nonce == -1


### PR DESCRIPTION
## Summary
- **MiningNode**: orquesta P2P + mining. Corre PoW en thread pool (no bloquea asyncio)
- **PoW interruptible**: `proof_of_work()` acepta `stop_event` (threading.Event), devuelve -1 si se interrumpe
- **Callback on_new_block**: cuando Node recibe un bloque válido de un peer, avisa al miner que pare y reintente con el nuevo tip
- **CLI actualizado**: `mine --address=X --port=9999` arranca un MiningNode completo

## Flujo
```
1. MiningNode.start()
   ├── initialize_chain() (genesis si no existe)
   ├── Node.start() (P2P server en asyncio)
   ├── connect_to_seeds() (background task)
   └── _mining_loop():
       ├── _build_block_template() (coinbase + mempool txns)
       ├── run_in_executor(_mine_block) (PoW en thread pool)
       │   ├── proof_of_work(block, stop_event)
       │   └── returns -1 if interrupted → restart loop
       ├── block.save()
       └── broadcast_block() (INV a todos los peers)

Cuando llega bloque de peer:
   Node._handle_block() → on_new_block callback → stop_event.set() → mining se interrumpe
```

## Test plan
- [x] PoW sin stop_event funciona normal
- [x] PoW con stop_event no seteado funciona normal
- [x] PoW con stop_event seteado devuelve -1 inmediatamente
- [x] PoW se interrumpe cuando stop_event se setea durante mining
- [x] MiningNode._build_block_template genera bloque correcto (height 0 y height N)
- [x] MiningNode._mine_block con dificultad fácil tiene éxito
- [x] MiningNode._mine_block se interrumpe con stop_event
- [x] _on_peer_block setea el stop_event
- [x] Node.on_new_block callback se dispara al recibir bloque válido
- [x] Callback NO se dispara cuando el bloque es rechazado
- [x] 292 tests totales pasando

🤖 Generated with [Claude Code](https://claude.com/claude-code)